### PR TITLE
# 20 checks for logistic regression

### DIFF
--- a/R/plot_or.R
+++ b/R/plot_or.R
@@ -41,9 +41,22 @@
 #' plot_or(lr)
 plot_or <- function(glm_model_results, conf_level = 0.95) {
 
+  # data and input checks ----
+  # check the model is logistic regression
+  if (!validate_glm_model(glm_model_results)) {
+    glm_family <- glm_model_results$family$family
+    cli::cli_abort(
+      message = c(
+        "{.arg glm_model_results} must be a {.pkg glm} object of 'binomial' family.",
+        "You've supplied a '{glm_family}' model."
+      )
+    )
+  }
+
   # limit conf_level to between 0.001 and 0.999
   conf_level <- validate_conf_level_input(conf_level)
 
+  # main ----
   # get the data from the model object
   df <- summarise_rows_per_variable_in_model(model_results = glm_model_results)
 
@@ -378,3 +391,20 @@ validate_conf_level_input <- function(conf_level) {
 
   return(conf_level_new)
 }
+
+#' Validate the `{glm}` model
+#'
+#' Check whether the glm model object is the product of logistic regression.
+#'
+#' @param glm_model Results from a binomial Generalised Linear Model (GLM), as produced by [stats::glm()]
+#'
+#' @returns boolean (TRUE = logistic regression, FALSE = other model)
+validate_glm_model <- function(glm_model) {
+  response <- (
+    class(glm_model)[1] == 'glm' & # must be a glm class object
+      glm_model$family$family == 'binomial' & # must be a binomial model
+      glm_model$family$link == 'logit' # must use logit link
+  )
+  return(response)
+}
+


### PR DESCRIPTION
closes #20 

# Checks model type
This PR introduces a check on the supplied `glm_model_results` to ensure it is a) a {glm} object which is, b) of 'binomial' family with 'logit' link (aka logistic regression).

Supplying a model other than this results in a error and a descriptive error:

```
df <- datasets::airquality

model <- stats::glm(
  data = df,
  formula = Temp ~ Month + Wind
)

plotor::plot_or(model)

#> Error in `plotor::plot_or()`:
#> ! `glm_model_results` must be a glm object of 'binomial' family.
#> You've supplied a 'gaussian' model.
#> Run `rlang::last_trace()` to see where the error occurred.
```