### PR TITLE
Test suite development

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,6 @@ Imports:
     scales,
     stats,
     stringr,
-    svglite,
     tidyselect
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
@@ -41,8 +40,10 @@ Suggests:
     knitr,
     labelled,
     rmarkdown,
+    svglite,
     testthat (>= 3.0.0),
-    tidyr
+    tidyr,
+    vdiffr
 VignetteBuilder: knitr
 URL: https://github.com/craig-parylo/plotor, https://craig-parylo.github.io/plotor/
 BugReports: https://github.com/craig-parylo/plotor/issues

--- a/R/plot_or.R
+++ b/R/plot_or.R
@@ -729,8 +729,8 @@ output_gt <- function(df, conf_level, title = "Odds Ratio Summary Table") {
     ) |>
     # add an OR plot to visualise the results
     gtExtras::gt_plt_conf_int(
-      column = .data$plot_or,
-      ci_columns = c(.data$plot_ci_l, .data$plot_ci_u),
+      column = 'plot_or',
+      ci_columns = c('plot_ci_l', 'plot_ci_u'),
       ref_line = 0,
       text_size = 0
     ) |>

--- a/tests/testthat/_snaps/plot_or.md
+++ b/tests/testthat/_snaps/plot_or.md
@@ -1,0 +1,38 @@
+# table_or() produces output equivalent to a snapshot
+
+    Code
+      lr <- readRDS(file = testthat::test_path("test_data", "lr_titanic.Rds"))
+      plotor::table_or(lr)
+    Output
+      # A tibble: 8 x 14
+        label      level  rows outcome outcome_rate class estimate std.error statistic
+        <fct>      <fct> <int>   <int>        <dbl> <chr>    <dbl>     <dbl>     <dbl>
+      1 Passenger~ 3rd     706     178        0.252 fact~    0.169     0.172    -10.4 
+      2 Passenger~ 1st     325     203        0.625 fact~   NA        NA         NA   
+      3 Passenger~ 2nd     285     118        0.414 fact~    0.361     0.196     -5.19
+      4 Passenger~ Crew    885     212        0.240 fact~    0.424     0.157     -5.45
+      5 Gender     Male   1731     367        0.212 fact~   NA        NA         NA   
+      6 Gender     Fema~   470     344        0.732 fact~   11.2       0.140     17.2 
+      7 Age at de~ Child   109      57        0.523 fact~    2.89      0.244      4.35
+      8 Age at de~ Adult  2092     654        0.313 fact~   NA        NA         NA   
+      # i 5 more variables: p.value <dbl>, conf.low <dbl>, conf.high <dbl>,
+      #   significance <chr>, comparator <dbl>
+
+# table_or() produces {gt} tables equivalent to a snapshot
+
+    Code
+      lr <- readRDS(file = testthat::test_path("test_data", "lr_titanic.Rds"))
+      plotor::table_or(lr, output = "gt")
+
+---
+
+    Code
+      lr <- readRDS(file = testthat::test_path("test_data", "lr_diabetes.Rds"))
+      plotor::table_or(lr, output = "gt")
+
+---
+
+    Code
+      lr <- readRDS(file = testthat::test_path("test_data", "lr_infert.Rds"))
+      plotor::table_or(lr, output = "gt")
+

--- a/tests/testthat/_snaps/plot_or/plot-diabetes.svg
+++ b/tests/testthat/_snaps/plot_or/plot-diabetes.svg
@@ -1,0 +1,302 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjc1LjAzfDcxNC41MnwzOC4xMnwxMTAuNTQ='>
+    <rect x='275.03' y='38.12' width='439.49' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjc1LjAzfDcxNC41MnwzOC4xMnwxMTAuNTQ=)'>
+<polyline points='275.03,74.33 714.52,74.33 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='320.08,110.54 320.08,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='367.56,110.54 367.56,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='413.86,110.54 413.86,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='459.05,110.54 459.05,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='503.18,110.54 503.18,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.29,110.54 546.29,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='588.43,110.54 588.43,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='629.65,110.54 629.65,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='669.98,110.54 669.98,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='709.46,110.54 709.46,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='367.56' y1='110.54' x2='367.56' y2='38.12' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='434.24,79.52 444.63,79.52 444.63,69.14 434.24,69.14 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='507.67,80.37 507.67,68.30 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='507.67,74.33 374.44,74.33 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='374.44,80.37 374.44,68.30 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjc1LjAzfDcxNC41MnwxMTAuNTR8MTgyLjk3'>
+    <rect x='275.03' y='110.54' width='439.49' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjc1LjAzfDcxNC41MnwxMTAuNTR8MTgyLjk3)'>
+<polyline points='275.03,146.76 714.52,146.76 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='320.08,182.97 320.08,110.54 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='367.56,182.97 367.56,110.54 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='413.86,182.97 413.86,110.54 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='459.05,182.97 459.05,110.54 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='503.18,182.97 503.18,110.54 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.29,182.97 546.29,110.54 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='588.43,182.97 588.43,110.54 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='629.65,182.97 629.65,110.54 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='669.98,182.97 669.98,110.54 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='709.46,182.97 709.46,110.54 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='367.56' y1='182.97' x2='367.56' y2='110.54' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='493.47,151.95 503.85,151.95 503.85,141.57 493.47,141.57 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='599.08,152.79 599.08,140.72 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='599.08,146.76 401.76,146.76 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='401.76,152.79 401.76,140.72 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjc1LjAzfDcxNC41MnwxODIuOTd8MjU1LjQw'>
+    <rect x='275.03' y='182.97' width='439.49' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjc1LjAzfDcxNC41MnwxODIuOTd8MjU1LjQw)'>
+<polyline points='275.03,219.19 714.52,219.19 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='320.08,255.40 320.08,182.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='367.56,255.40 367.56,182.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='413.86,255.40 413.86,182.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='459.05,255.40 459.05,182.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='503.18,255.40 503.18,182.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.29,255.40 546.29,182.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='588.43,255.40 588.43,182.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='629.65,255.40 629.65,182.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='669.98,255.40 669.98,182.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='709.46,255.40 709.46,182.97 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='367.56' y1='255.40' x2='367.56' y2='182.97' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='488.23,224.38 498.61,224.38 498.61,213.99 488.23,213.99 ' style='stroke-width: 0.71; stroke: none; fill: #487EB0;' />
+<polyline points='694.54,225.22 694.54,213.15 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='694.54,219.19 295.01,219.19 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='295.01,225.22 295.01,213.15 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjc1LjAzfDcxNC41MnwyNTUuNDB8MzI3Ljgz'>
+    <rect x='275.03' y='255.40' width='439.49' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjc1LjAzfDcxNC41MnwyNTUuNDB8MzI3Ljgz)'>
+<polyline points='275.03,291.61 714.52,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='320.08,327.83 320.08,255.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='367.56,327.83 367.56,255.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='413.86,327.83 413.86,255.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='459.05,327.83 459.05,255.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='503.18,327.83 503.18,255.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.29,327.83 546.29,255.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='588.43,327.83 588.43,255.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='629.65,327.83 629.65,255.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='669.98,327.83 669.98,255.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='709.46,327.83 709.46,255.40 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='367.56' y1='327.83' x2='367.56' y2='255.40' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='433.37,296.81 443.76,296.81 443.76,286.42 433.37,286.42 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='460.34,297.65 460.34,285.58 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='460.34,291.61 418.33,291.61 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='418.33,297.65 418.33,285.58 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjc1LjAzfDcxNC41MnwzMjcuODN8NDAwLjI2'>
+    <rect x='275.03' y='327.83' width='439.49' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjc1LjAzfDcxNC41MnwzMjcuODN8NDAwLjI2)'>
+<polyline points='275.03,364.04 714.52,364.04 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='320.08,400.26 320.08,327.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='367.56,400.26 367.56,327.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='413.86,400.26 413.86,327.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='459.05,400.26 459.05,327.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='503.18,400.26 503.18,327.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.29,400.26 546.29,327.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='588.43,400.26 588.43,327.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='629.65,400.26 629.65,327.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='669.98,400.26 669.98,327.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='709.46,400.26 709.46,327.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='367.56' y1='400.26' x2='367.56' y2='327.83' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='355.88,369.24 366.27,369.24 366.27,358.85 355.88,358.85 ' style='stroke-width: 0.71; stroke: none; fill: #487EB0;' />
+<polyline points='403.78,370.08 403.78,358.01 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='403.78,364.04 318.78,364.04 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='318.78,370.08 318.78,358.01 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjc1LjAzfDcxNC41Mnw0MDAuMjZ8NDcyLjY4'>
+    <rect x='275.03' y='400.26' width='439.49' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjc1LjAzfDcxNC41Mnw0MDAuMjZ8NDcyLjY4)'>
+<polyline points='275.03,436.47 714.52,436.47 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='320.08,472.68 320.08,400.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='367.56,472.68 367.56,400.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='413.86,472.68 413.86,400.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='459.05,472.68 459.05,400.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='503.18,472.68 503.18,400.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.29,472.68 546.29,400.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='588.43,472.68 588.43,400.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='629.65,472.68 629.65,400.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='669.98,472.68 669.98,400.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='709.46,472.68 709.46,400.26 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='367.56' y1='472.68' x2='367.56' y2='400.26' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='390.75,441.66 401.14,441.66 401.14,431.28 390.75,431.28 ' style='stroke-width: 0.71; stroke: none; fill: #487EB0;' />
+<polyline points='458.15,442.51 458.15,430.43 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='458.15,436.47 333.77,436.47 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='333.77,442.51 333.77,430.43 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjc1LjAzfDcxNC41Mnw0NzIuNjh8NTQ1LjEx'>
+    <rect x='275.03' y='472.68' width='439.49' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjc1LjAzfDcxNC41Mnw0NzIuNjh8NTQ1LjEx)'>
+<polyline points='275.03,508.90 714.52,508.90 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='320.08,545.11 320.08,472.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='367.56,545.11 367.56,472.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='413.86,545.11 413.86,472.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='459.05,545.11 459.05,472.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='503.18,545.11 503.18,472.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.29,545.11 546.29,472.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='588.43,545.11 588.43,472.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='629.65,545.11 629.65,472.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='669.98,545.11 669.98,472.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='709.46,545.11 709.46,472.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='367.56' y1='545.11' x2='367.56' y2='472.68' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='361.15,514.09 371.54,514.09 371.54,503.70 361.15,503.70 ' style='stroke-width: 0.71; stroke: none; fill: #487EB0;' />
+<polyline points='371.15,514.93 371.15,502.86 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='371.15,508.90 361.63,508.90 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='361.63,514.93 361.63,502.86 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNjcuNzl8MzguMTJ8MTEwLjU0'>
+    <rect x='5.48' y='38.12' width='162.31' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNjcuNzl8MzguMTJ8MTEwLjU0)'>
+<text x='82.25' y='77.36' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='45.49px' lengthAdjust='spacingAndGlyphs'>Age (years)</text>
+<text x='163.41' y='77.36' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>age</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNjcuNzl8MTEwLjU0fDE4Mi45Nw=='>
+    <rect x='5.48' y='110.54' width='162.31' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNjcuNzl8MTEwLjU0fDE4Mi45Nw==)'>
+<text x='82.25' y='149.79' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='67.03px' lengthAdjust='spacingAndGlyphs'>Body mass index</text>
+<text x='163.41' y='149.79' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='14.18px' lengthAdjust='spacingAndGlyphs'>bmi</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNjcuNzl8MTgyLjk3fDI1NS40MA=='>
+    <rect x='5.48' y='182.97' width='162.31' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNjcuNzl8MTgyLjk3fDI1NS40MA==)'>
+<text x='82.25' y='217.46' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='41.09px' lengthAdjust='spacingAndGlyphs'>Number of</text>
+<text x='82.25' y='226.97' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='47.95px' lengthAdjust='spacingAndGlyphs'>pregnancies</text>
+<text x='163.41' y='222.21' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='63.12px' lengthAdjust='spacingAndGlyphs'>pregnancy_num</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNjcuNzl8MjU1LjQwfDMyNy44Mw=='>
+    <rect x='5.48' y='255.40' width='162.31' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNjcuNzl8MjU1LjQwfDMyNy44Mw==)'>
+<text x='82.25' y='285.14' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='62.14px' lengthAdjust='spacingAndGlyphs'>Plasma glucose</text>
+<text x='82.25' y='294.64' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='52.84px' lengthAdjust='spacingAndGlyphs'>concentration</text>
+<text x='82.25' y='304.15' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='42.55px' lengthAdjust='spacingAndGlyphs'>(mg per dl)</text>
+<text x='163.41' y='294.64' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='59.20px' lengthAdjust='spacingAndGlyphs'>glucose_mg_dl</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNjcuNzl8MzI3LjgzfDQwMC4yNg=='>
+    <rect x='5.48' y='327.83' width='162.31' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNjcuNzl8MzI3LjgzfDQwMC4yNg==)'>
+<text x='82.25' y='362.32' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='57.24px' lengthAdjust='spacingAndGlyphs'>Diastolic blood</text>
+<text x='82.25' y='371.82' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='68.47px' lengthAdjust='spacingAndGlyphs'>pressure (mmHg)</text>
+<text x='163.41' y='367.07' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='48.93px' lengthAdjust='spacingAndGlyphs'>dbp_mm_hg</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNjcuNzl8NDAwLjI2fDQ3Mi42OA=='>
+    <rect x='5.48' y='400.26' width='162.31' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNjcuNzl8NDAwLjI2fDQ3Mi42OA==)'>
+<text x='82.25' y='429.99' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='46.96px' lengthAdjust='spacingAndGlyphs'>Triceps skin</text>
+<text x='82.25' y='439.50' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.33px' lengthAdjust='spacingAndGlyphs'>fold thickness</text>
+<text x='82.25' y='449.00' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='20.53px' lengthAdjust='spacingAndGlyphs'>(mm)</text>
+<text x='163.41' y='439.50' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='45.49px' lengthAdjust='spacingAndGlyphs'>triceps_mm</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNjcuNzl8NDcyLjY4fDU0NS4xMQ=='>
+    <rect x='5.48' y='472.68' width='162.31' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNjcuNzl8NDcyLjY4fDU0NS4xMQ==)'>
+<text x='82.25' y='502.42' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Serum insulin</text>
+<text x='82.25' y='511.93' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='48.41px' lengthAdjust='spacingAndGlyphs'>(microIU per</text>
+<text x='82.25' y='521.43' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>ml)</text>
+<text x='163.41' y='511.93' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='72.39px' lengthAdjust='spacingAndGlyphs'>insulin_microiu_ml</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='320.08' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>0.975</text>
+<text x='367.56' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>1.000</text>
+<text x='413.86' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>1.025</text>
+<text x='459.05' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>1.050</text>
+<text x='503.18' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>1.075</text>
+<text x='546.29' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>1.100</text>
+<text x='588.43' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>1.125</text>
+<text x='629.65' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>1.150</text>
+<text x='669.98' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>1.175</text>
+<text x='709.46' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>1.200</text>
+<text x='270.10' y='77.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='87.34px' lengthAdjust='spacingAndGlyphs'>1.04 (1-1.08, p=0.034)</text>
+<text x='270.10' y='149.79' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>1.07 (1.02-1.13, p=0.009)</text>
+<text x='270.10' y='222.21' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>1.07 (0.96-1.19, p=0.215)</text>
+<text x='270.10' y='294.64' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>1.04 (1.03-1.05, p&lt;0.001)</text>
+<text x='270.10' y='367.07' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='87.34px' lengthAdjust='spacingAndGlyphs'>1 (0.97-1.02, p=0.764)</text>
+<text x='270.10' y='439.50' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='94.68px' lengthAdjust='spacingAndGlyphs'>1.02 (0.98-1.05, p=0.37)</text>
+<text x='270.10' y='511.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='62.87px' lengthAdjust='spacingAndGlyphs'>1 (1-1, p=0.616)</text>
+<text x='494.78' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='146.74px' lengthAdjust='spacingAndGlyphs'>Odds ratio (95% CI, log scale)</text>
+<text x='5.48' y='30.35' style='font-size: 11.00px; font-family: sans;' textLength='269.64px' lengthAdjust='spacingAndGlyphs'>Odds Ratio (OR) plot with 95% Confidence Interval (CI)</text>
+<text x='5.48' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='242.16px' lengthAdjust='spacingAndGlyphs'>Diagnosis of diabetes in following 5 years</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/plot_or/plot-infert.svg
+++ b/tests/testthat/_snaps/plot_or/plot-infert.svg
@@ -1,0 +1,408 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41MnwzOC4xMnw4NC4yMQ=='>
+    <rect x='272.11' y='38.12' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41MnwzOC4xMnw4NC4yMQ==)'>
+<polyline points='272.11,61.16 714.52,61.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,84.21 328.23,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,84.21 380.26,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,84.21 437.29,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,84.21 489.33,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,84.21 546.35,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,84.21 598.39,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,84.21 655.41,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,84.21 707.45,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='84.21' x2='437.29' y2='38.12' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='437.73,62.58 440.57,62.58 440.57,59.74 437.73,59.74 ' style='stroke-width: 0.71; stroke: none; fill: #487EB0;' />
+<polyline points='442.13,65.00 442.13,57.32 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='442.13,61.16 436.24,61.16 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='436.24,65.00 436.24,57.32 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41Mnw4NC4yMXwxMzAuMzA='>
+    <rect x='272.11' y='84.21' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41Mnw4NC4yMXwxMzAuMzA=)'>
+<polyline points='272.11,107.25 714.52,107.25 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,130.30 328.23,84.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,130.30 380.26,84.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,130.30 437.29,84.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,130.30 489.33,84.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,130.30 546.35,84.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,130.30 598.39,84.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,130.30 655.41,84.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,130.30 707.45,84.21 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='130.30' x2='437.29' y2='84.21' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='396.55,108.67 399.39,108.67 399.39,105.83 396.55,105.83 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='415.54,111.09 415.54,103.41 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='415.54,107.25 378.66,107.25 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='378.66,111.09 378.66,103.41 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41MnwxMzAuMzB8MTc2LjM5'>
+    <rect x='272.11' y='130.30' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41MnwxMzAuMzB8MTc2LjM5)'>
+<polyline points='272.11,153.34 714.52,153.34 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,176.39 328.23,130.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,176.39 380.26,130.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,176.39 437.29,130.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,176.39 489.33,130.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,176.39 546.35,130.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,176.39 598.39,130.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,176.39 655.41,130.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,176.39 707.45,130.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='176.39' x2='437.29' y2='130.30' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='435.87,154.76 438.71,154.76 438.71,151.92 435.87,151.92 ' style='stroke-width: 0.71; stroke: none; fill: #718093;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41MnwxNzYuMzl8MjIyLjQ4'>
+    <rect x='272.11' y='176.39' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41MnwxNzYuMzl8MjIyLjQ4)'>
+<polyline points='272.11,199.43 714.52,199.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,222.48 328.23,176.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,222.48 380.26,176.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,222.48 437.29,176.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,222.48 489.33,176.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,222.48 546.35,176.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,222.48 598.39,176.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,222.48 655.41,176.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,222.48 707.45,176.39 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='222.48' x2='437.29' y2='176.39' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='364.92,205.61 377.27,205.61 377.27,193.26 364.92,193.26 ' style='stroke-width: 0.71; stroke: none; fill: #487EB0;' />
+<polyline points='450.09,203.27 450.09,195.59 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='450.09,199.43 292.22,199.43 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='292.22,203.27 292.22,195.59 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41MnwyMjIuNDh8MjY4LjU3'>
+    <rect x='272.11' y='222.48' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41MnwyMjIuNDh8MjY4LjU3)'>
+<polyline points='272.11,245.52 714.52,245.52 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,268.57 328.23,222.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,268.57 380.26,222.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,268.57 437.29,222.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,268.57 489.33,222.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,268.57 546.35,222.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,268.57 598.39,222.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,268.57 655.41,222.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,268.57 707.45,222.48 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='268.57' x2='437.29' y2='222.48' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='381.79,251.79 394.32,251.79 394.32,239.26 381.79,239.26 ' style='stroke-width: 0.71; stroke: none; fill: #487EB0;' />
+<polyline points='463.90,249.36 463.90,241.68 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='463.90,245.52 313.62,245.52 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+<polyline points='313.62,249.36 313.62,241.68 ' style='stroke-width: 1.07; stroke: #487EB0; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41MnwyNjguNTd8MzE0LjY2'>
+    <rect x='272.11' y='268.57' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41MnwyNjguNTd8MzE0LjY2)'>
+<polyline points='272.11,291.61 714.52,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,314.66 328.23,268.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,314.66 380.26,268.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,314.66 437.29,268.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,314.66 489.33,268.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,314.66 546.35,268.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,314.66 598.39,268.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,314.66 655.41,268.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,314.66 707.45,268.57 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='314.66' x2='437.29' y2='268.57' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='430.53,298.37 444.05,298.37 444.05,284.86 430.53,284.86 ' style='stroke-width: 0.71; stroke: none; fill: #718093;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41MnwzMTQuNjZ8MzYwLjc1'>
+    <rect x='272.11' y='314.66' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41MnwzMTQuNjZ8MzYwLjc1)'>
+<polyline points='272.11,337.71 714.52,337.71 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,360.75 328.23,314.66 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,360.75 380.26,314.66 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,360.75 437.29,314.66 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,360.75 489.33,314.66 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,360.75 546.35,314.66 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,360.75 598.39,314.66 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,360.75 655.41,314.66 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,360.75 707.45,314.66 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='360.75' x2='437.29' y2='314.66' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='492.01,342.61 501.83,342.61 501.83,332.80 492.01,332.80 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='536.71,341.55 536.71,333.86 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='536.71,337.71 459.11,337.71 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='459.11,341.55 459.11,333.86 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41MnwzNjAuNzV8NDA2Ljg0'>
+    <rect x='272.11' y='360.75' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41MnwzNjAuNzV8NDA2Ljg0)'>
+<polyline points='272.11,383.80 714.52,383.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,406.84 328.23,360.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,406.84 380.26,360.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,406.84 437.29,360.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,406.84 489.33,360.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,406.84 546.35,360.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,406.84 598.39,360.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,406.84 655.41,360.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,406.84 707.45,360.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='406.84' x2='437.29' y2='360.75' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='556.31,387.55 563.81,387.55 563.81,380.04 556.31,380.04 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='619.27,387.64 619.27,379.95 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='619.27,383.80 503.95,383.80 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='503.95,387.64 503.95,379.95 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41Mnw0MDYuODR8NDUyLjkz'>
+    <rect x='272.11' y='406.84' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41Mnw0MDYuODR8NDUyLjkz)'>
+<polyline points='272.11,429.89 714.52,429.89 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,452.93 328.23,406.84 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,452.93 380.26,406.84 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,452.93 437.29,406.84 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,452.93 489.33,406.84 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,452.93 546.35,406.84 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,452.93 598.39,406.84 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,452.93 655.41,406.84 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,452.93 707.45,406.84 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='452.93' x2='437.29' y2='406.84' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='430.58,436.60 444.01,436.60 444.01,423.17 430.58,423.17 ' style='stroke-width: 0.71; stroke: none; fill: #718093;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41Mnw0NTIuOTN8NDk5LjAy'>
+    <rect x='272.11' y='452.93' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41Mnw0NTIuOTN8NDk5LjAy)'>
+<polyline points='272.11,475.98 714.52,475.98 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,499.02 328.23,452.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,499.02 380.26,452.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,499.02 437.29,452.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,499.02 489.33,452.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,499.02 546.35,452.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,499.02 598.39,452.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,499.02 655.41,452.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,499.02 707.45,452.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='499.02' x2='437.29' y2='452.93' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='528.49,480.98 538.49,480.98 538.49,470.98 528.49,470.98 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='572.57,479.82 572.57,472.14 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='572.57,475.98 496.97,475.98 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='496.97,479.82 496.97,472.14 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcyLjExfDcxNC41Mnw0OTkuMDJ8NTQ1LjEx'>
+    <rect x='272.11' y='499.02' width='442.41' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcyLjExfDcxNC41Mnw0OTkuMDJ8NTQ1LjEx)'>
+<polyline points='272.11,522.07 714.52,522.07 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.23,545.11 328.23,499.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='380.26,545.11 380.26,499.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.29,545.11 437.29,499.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='489.33,545.11 489.33,499.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='546.35,545.11 546.35,499.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='598.39,545.11 598.39,499.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='655.41,545.11 655.41,499.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='707.45,545.11 707.45,499.02 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='437.29' y1='545.11' x2='437.29' y2='499.02' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='627.72,525.77 635.13,525.77 635.13,518.36 627.72,518.36 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='694.41,525.91 694.41,518.23 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='694.41,522.07 574.52,522.07 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='574.52,525.91 574.52,518.23 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8MzguMTJ8ODQuMjE='>
+    <rect x='5.48' y='38.12' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8MzguMTJ8ODQuMjE=)'>
+<text x='71.00' y='64.19' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='45.49px' lengthAdjust='spacingAndGlyphs'>Age (years)</text>
+<text x='140.90' y='64.19' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>age</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8ODQuMjF8MTMwLjMw'>
+    <rect x='5.48' y='84.21' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8ODQuMjF8MTMwLjMw)'>
+<text x='71.00' y='110.28' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='23.49px' lengthAdjust='spacingAndGlyphs'>Count</text>
+<text x='140.90' y='110.28' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='21.52px' lengthAdjust='spacingAndGlyphs'>parity</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8MTMwLjMwfDE3Ni4zOQ=='>
+    <rect x='5.48' y='130.30' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8MTMwLjMwfDE3Ni4zOQ==)'>
+<text x='71.00' y='151.62' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='39.15px' lengthAdjust='spacingAndGlyphs'>Education</text>
+<text x='71.00' y='161.12' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='27.39px' lengthAdjust='spacingAndGlyphs'>(years)</text>
+<text x='140.90' y='156.37' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='24.46px' lengthAdjust='spacingAndGlyphs'>0-5yrs</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8MTc2LjM5fDIyMi40OA=='>
+    <rect x='5.48' y='176.39' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8MTc2LjM5fDIyMi40OA==)'>
+<text x='140.90' y='202.46' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='29.11px' lengthAdjust='spacingAndGlyphs'>12+ yrs</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8MjIyLjQ4fDI2OC41Nw=='>
+    <rect x='5.48' y='222.48' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8MjIyLjQ4fDI2OC41Nw==)'>
+<text x='140.90' y='248.55' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>6-11yrs</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8MjY4LjU3fDMxNC42Ng=='>
+    <rect x='5.48' y='268.57' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8MjY4LjU3fDMxNC42Ng==)'>
+<text x='71.00' y='285.14' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='41.09px' lengthAdjust='spacingAndGlyphs'>Number of</text>
+<text x='71.00' y='294.64' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='50.88px' lengthAdjust='spacingAndGlyphs'>prior induced</text>
+<text x='71.00' y='304.15' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='36.20px' lengthAdjust='spacingAndGlyphs'>abortions</text>
+<text x='140.90' y='294.64' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8MzE0LjY2fDM2MC43NQ=='>
+    <rect x='5.48' y='314.66' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8MzE0LjY2fDM2MC43NQ==)'>
+<text x='140.90' y='340.73' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8MzYwLjc1fDQwNi44NA=='>
+    <rect x='5.48' y='360.75' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8MzYwLjc1fDQwNi44NA==)'>
+<text x='140.90' y='386.82' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='37.66px' lengthAdjust='spacingAndGlyphs'>2 or more</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8NDA2Ljg0fDQ1Mi45Mw=='>
+    <rect x='5.48' y='406.84' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8NDA2Ljg0fDQ1Mi45Mw==)'>
+<text x='71.00' y='423.41' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='61.14px' lengthAdjust='spacingAndGlyphs'>Number of prior</text>
+<text x='71.00' y='432.91' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='50.41px' lengthAdjust='spacingAndGlyphs'>spontaneous</text>
+<text x='71.00' y='442.42' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='36.20px' lengthAdjust='spacingAndGlyphs'>abortions</text>
+<text x='140.90' y='432.91' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8NDUyLjkzfDQ5OS4wMg=='>
+    <rect x='5.48' y='452.93' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8NDUyLjkzfDQ5OS4wMg==)'>
+<text x='140.90' y='479.00' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNDUuMjl8NDk5LjAyfDU0NS4xMQ=='>
+    <rect x='5.48' y='499.02' width='139.81' height='46.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNDUuMjl8NDk5LjAyfDU0NS4xMQ==)'>
+<text x='140.90' y='525.10' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='37.66px' lengthAdjust='spacingAndGlyphs'>2 or more</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='328.23' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='380.26' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='437.29' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='489.33' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='546.35' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='598.39' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>30.0</text>
+<text x='655.41' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>100.0</text>
+<text x='707.45' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>300.0</text>
+<text x='267.18' y='64.19' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>1.04 (0.98-1.11, p=0.213)</text>
+<text x='267.18' y='110.28' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>0.44 (0.29-0.63, p&lt;0.001)</text>
+<text x='267.18' y='156.37' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='90.99px' lengthAdjust='spacingAndGlyphs'>education (comparator)</text>
+<text x='267.18' y='202.46' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>0.25 (0.05-1.31, p=0.094)</text>
+<text x='267.18' y='248.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='94.68px' lengthAdjust='spacingAndGlyphs'>0.35 (0.07-1.75, p=0.19)</text>
+<text x='267.18' y='294.64' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='83.65px' lengthAdjust='spacingAndGlyphs'>induced (comparator)</text>
+<text x='267.18' y='340.73' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>3.52 (1.58-8.16, p=0.002)</text>
+<text x='267.18' y='386.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='109.36px' lengthAdjust='spacingAndGlyphs'>13.36 (4.09-46.63, p&lt;0.001)</text>
+<text x='267.18' y='432.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='103.23px' lengthAdjust='spacingAndGlyphs'>spontaneous (comparator)</text>
+<text x='267.18' y='479.00' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>7.62 (3.53-17.4, p&lt;0.001)</text>
+<text x='267.18' y='525.10' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='119.15px' lengthAdjust='spacingAndGlyphs'>60.27 (18.13-227.81, p&lt;0.001)</text>
+<text x='493.31' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='146.74px' lengthAdjust='spacingAndGlyphs'>Odds ratio (95% CI, log scale)</text>
+<text x='5.48' y='30.35' style='font-size: 11.00px; font-family: sans;' textLength='269.64px' lengthAdjust='spacingAndGlyphs'>Odds Ratio (OR) plot with 95% Confidence Interval (CI)</text>
+<text x='5.48' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='69.72px' lengthAdjust='spacingAndGlyphs'>Case status</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/plot_or/plot-titanic.svg
+++ b/tests/testthat/_snaps/plot_or/plot-titanic.svg
@@ -1,0 +1,308 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY5LjIxfDcxNC41MnwzOC4xMnwxMDEuNDk='>
+    <rect x='269.21' y='38.12' width='445.31' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY5LjIxfDcxNC41MnwzOC4xMnwxMDEuNDk=)'>
+<polyline points='269.21,69.80 714.52,69.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='273.91,101.49 273.91,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='332.16,101.49 332.16,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='366.24,101.49 366.24,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='409.17,101.49 409.17,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='467.42,101.49 467.42,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='525.67,101.49 525.67,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.75,101.49 559.75,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='602.68,101.49 602.68,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='660.93,101.49 660.93,38.12 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='467.42' y1='101.49' x2='467.42' y2='38.12' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='464.24,72.99 470.60,72.99 470.60,66.62 464.24,66.62 ' style='stroke-width: 0.71; stroke: none; fill: #718093;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY5LjIxfDcxNC41MnwxMDEuNDl8MTY0Ljg3'>
+    <rect x='269.21' y='101.49' width='445.31' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY5LjIxfDcxNC41MnwxMDEuNDl8MTY0Ljg3)'>
+<polyline points='269.21,133.18 714.52,133.18 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='273.91,164.87 273.91,101.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='332.16,164.87 332.16,101.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='366.24,164.87 366.24,101.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='409.17,164.87 409.17,101.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='467.42,164.87 467.42,101.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='525.67,164.87 525.67,101.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.75,164.87 559.75,101.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='602.68,164.87 602.68,101.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='660.93,164.87 660.93,101.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='467.42' y1='164.87' x2='467.42' y2='101.49' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='378.85,136.19 384.87,136.19 384.87,130.17 378.85,130.17 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='413.94,138.46 413.94,127.90 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='413.94,133.18 349.32,133.18 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='349.32,138.46 349.32,127.90 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY5LjIxfDcxNC41MnwxNjQuODd8MjI4LjI0'>
+    <rect x='269.21' y='164.87' width='445.31' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY5LjIxfDcxNC41MnwxNjQuODd8MjI4LjI0)'>
+<polyline points='269.21,196.55 714.52,196.55 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='273.91,228.24 273.91,164.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='332.16,228.24 332.16,164.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='366.24,228.24 366.24,164.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='409.17,228.24 409.17,164.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='467.42,228.24 467.42,164.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='525.67,228.24 525.67,164.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.75,228.24 559.75,164.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='602.68,228.24 602.68,164.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='660.93,228.24 660.93,164.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='467.42' y1='228.24' x2='467.42' y2='164.87' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='313.67,200.90 322.36,200.90 322.36,192.20 313.67,192.20 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='346.02,201.83 346.02,191.27 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='346.02,196.55 289.46,196.55 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='289.46,201.83 289.46,191.27 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY5LjIxfDcxNC41MnwyMjguMjR8MjkxLjYx'>
+    <rect x='269.21' y='228.24' width='445.31' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY5LjIxfDcxNC41MnwyMjguMjR8MjkxLjYx)'>
+<polyline points='269.21,259.93 714.52,259.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='273.91,291.61 273.91,228.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='332.16,291.61 332.16,228.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='366.24,291.61 366.24,228.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='409.17,291.61 409.17,228.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='467.42,291.61 467.42,228.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='525.67,291.61 525.67,228.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.75,291.61 559.75,228.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='602.68,291.61 602.68,228.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='660.93,291.61 660.93,228.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='467.42' y1='291.61' x2='467.42' y2='228.24' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='390.58,264.69 400.10,264.69 400.10,255.17 390.58,255.17 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='421.27,265.21 421.27,254.65 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='421.27,259.93 369.40,259.93 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='369.40,265.21 369.40,254.65 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY5LjIxfDcxNC41MnwyOTEuNjF8MzU0Ljk5'>
+    <rect x='269.21' y='291.61' width='445.31' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY5LjIxfDcxNC41MnwyOTEuNjF8MzU0Ljk5)'>
+<polyline points='269.21,323.30 714.52,323.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='273.91,354.99 273.91,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='332.16,354.99 332.16,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='366.24,354.99 366.24,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='409.17,354.99 409.17,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='467.42,354.99 467.42,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='525.67,354.99 525.67,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.75,354.99 559.75,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='602.68,354.99 602.68,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='660.93,354.99 660.93,291.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='467.42' y1='354.99' x2='467.42' y2='291.61' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='461.18,329.55 473.67,329.55 473.67,317.06 461.18,317.06 ' style='stroke-width: 0.71; stroke: none; fill: #718093;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY5LjIxfDcxNC41MnwzNTQuOTl8NDE4LjM2'>
+    <rect x='269.21' y='354.99' width='445.31' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY5LjIxfDcxNC41MnwzNTQuOTl8NDE4LjM2)'>
+<polyline points='269.21,386.68 714.52,386.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='273.91,418.36 273.91,354.99 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='332.16,418.36 332.16,354.99 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='366.24,418.36 366.24,354.99 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='409.17,418.36 409.17,354.99 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='467.42,418.36 467.42,354.99 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='525.67,418.36 525.67,354.99 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.75,418.36 559.75,354.99 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='602.68,418.36 602.68,354.99 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='660.93,418.36 660.93,354.99 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='467.42' y1='418.36' x2='467.42' y2='354.99' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='667.11,390.37 674.50,390.37 674.50,382.98 667.11,382.98 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='694.28,391.96 694.28,381.40 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='694.28,386.68 647.99,386.68 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='647.99,391.96 647.99,381.40 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY5LjIxfDcxNC41Mnw0MTguMzZ8NDgxLjc0'>
+    <rect x='269.21' y='418.36' width='445.31' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY5LjIxfDcxNC41Mnw0MTguMzZ8NDgxLjc0)'>
+<polyline points='269.21,450.05 714.52,450.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='273.91,481.74 273.91,418.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='332.16,481.74 332.16,418.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='366.24,481.74 366.24,418.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='409.17,481.74 409.17,418.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='467.42,481.74 467.42,418.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='525.67,481.74 525.67,418.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.75,481.74 559.75,418.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='602.68,481.74 602.68,418.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='660.93,481.74 660.93,418.36 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='467.42' y1='481.74' x2='467.42' y2='418.36' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='460.67,456.81 474.18,456.81 474.18,443.29 460.67,443.29 ' style='stroke-width: 0.71; stroke: none; fill: #718093;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY5LjIxfDcxNC41Mnw0ODEuNzR8NTQ1LjEx'>
+    <rect x='269.21' y='481.74' width='445.31' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY5LjIxfDcxNC41Mnw0ODEuNzR8NTQ1LjEx)'>
+<polyline points='269.21,513.43 714.52,513.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='273.91,545.11 273.91,481.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='332.16,545.11 332.16,481.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='366.24,545.11 366.24,481.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='409.17,545.11 409.17,481.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='467.42,545.11 467.42,481.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='525.67,545.11 525.67,481.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.75,545.11 559.75,481.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='602.68,545.11 602.68,481.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='660.93,545.11 660.93,481.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<line x1='467.42' y1='545.11' x2='467.42' y2='481.74' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<polygon points='555.21,514.85 558.06,514.85 558.06,512.00 555.21,512.00 ' style='stroke-width: 0.71; stroke: none; fill: #192A56;' />
+<polyline points='596.96,518.71 596.96,508.14 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='596.96,513.43 516.47,513.43 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+<polyline points='516.47,518.71 516.47,508.14 ' style='stroke-width: 1.07; stroke: #192A56; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNTIuMTh8MzguMTJ8MTAxLjQ5'>
+    <rect x='5.48' y='38.12' width='146.70' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNTIuMTh8MzguMTJ8MTAxLjQ5)'>
+<text x='74.45' y='72.83' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='64.58px' lengthAdjust='spacingAndGlyphs'>Passenger class</text>
+<text x='147.80' y='72.83' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='11.74px' lengthAdjust='spacingAndGlyphs'>1st</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNTIuMTh8MTAxLjQ5fDE2NC44Nw=='>
+    <rect x='5.48' y='101.49' width='146.70' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNTIuMTh8MTAxLjQ5fDE2NC44Nw==)'>
+<text x='147.80' y='136.21' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>2nd</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNTIuMTh8MTY0Ljg3fDIyOC4yNA=='>
+    <rect x='5.48' y='164.87' width='146.70' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNTIuMTh8MTY0Ljg3fDIyOC4yNA==)'>
+<text x='147.80' y='199.58' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='12.72px' lengthAdjust='spacingAndGlyphs'>3rd</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNTIuMTh8MjI4LjI0fDI5MS42MQ=='>
+    <rect x='5.48' y='228.24' width='146.70' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNTIuMTh8MjI4LjI0fDI5MS42MQ==)'>
+<text x='147.80' y='262.96' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='20.54px' lengthAdjust='spacingAndGlyphs'>Crew</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNTIuMTh8MjkxLjYxfDM1NC45OQ=='>
+    <rect x='5.48' y='291.61' width='146.70' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNTIuMTh8MjkxLjYxfDM1NC45OQ==)'>
+<text x='74.45' y='326.33' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='29.36px' lengthAdjust='spacingAndGlyphs'>Gender</text>
+<text x='147.80' y='326.33' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='19.08px' lengthAdjust='spacingAndGlyphs'>Male</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNTIuMTh8MzU0Ljk5fDQxOC4zNg=='>
+    <rect x='5.48' y='354.99' width='146.70' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNTIuMTh8MzU0Ljk5fDQxOC4zNg==)'>
+<text x='147.80' y='389.70' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>Female</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNTIuMTh8NDE4LjM2fDQ4MS43NA=='>
+    <rect x='5.48' y='418.36' width='146.70' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNTIuMTh8NDE4LjM2fDQ4MS43NA==)'>
+<text x='74.45' y='453.08' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='49.91px' lengthAdjust='spacingAndGlyphs'>Age at death</text>
+<text x='147.80' y='453.08' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>Adult</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHwxNTIuMTh8NDgxLjc0fDU0NS4xMQ=='>
+    <rect x='5.48' y='481.74' width='146.70' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHwxNTIuMTh8NDgxLjc0fDU0NS4xMQ==)'>
+<text x='147.80' y='516.45' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='20.05px' lengthAdjust='spacingAndGlyphs'>Child</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='273.91' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='332.16' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='366.24' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='409.17' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='467.42' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='525.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='559.75' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='602.68' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='660.93' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='264.28' y='72.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='74.83px' lengthAdjust='spacingAndGlyphs'>Class (comparator)</text>
+<text x='264.28' y='136.21' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>0.36 (0.25-0.53, p&lt;0.001)</text>
+<text x='264.28' y='199.58' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>0.17 (0.12-0.24, p&lt;0.001)</text>
+<text x='264.28' y='262.96' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>0.42 (0.31-0.58, p&lt;0.001)</text>
+<text x='264.28' y='326.33' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='67.99px' lengthAdjust='spacingAndGlyphs'>Sex (comparator)</text>
+<text x='264.28' y='389.70' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='109.36px' lengthAdjust='spacingAndGlyphs'>11.25 (8.57-14.87, p&lt;0.001)</text>
+<text x='264.28' y='453.08' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='68.48px' lengthAdjust='spacingAndGlyphs'>Age (comparator)</text>
+<text x='264.28' y='516.45' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='99.57px' lengthAdjust='spacingAndGlyphs'>2.89 (1.79-4.67, p&lt;0.001)</text>
+<text x='491.87' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='146.74px' lengthAdjust='spacingAndGlyphs'>Odds ratio (95% CI, log scale)</text>
+<text x='5.48' y='30.35' style='font-size: 11.00px; font-family: sans;' textLength='269.64px' lengthAdjust='spacingAndGlyphs'>Odds Ratio (OR) plot with 95% Confidence Interval (CI)</text>
+<text x='5.48' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='51.37px' lengthAdjust='spacingAndGlyphs'>Survived</text>
+</g>
+</svg>

--- a/tests/testthat/test-plot_or.R
+++ b/tests/testthat/test-plot_or.R
@@ -1,38 +1,135 @@
 # main functions ---------------------------------------------------------------
-testthat::test_that("plot_or() does not produce messages or warnings", {
-  testthat::expect_silent({
 
-    # titanic lr model
+## test successful ----
+testthat::test_that("plot_or() does not produce messages or warnings", {
+
+  # titanic lr model
+  testthat::expect_silent({
     lr <- readRDS(file = testthat::test_path('test_data', 'lr_titanic.Rds'))
     plotor::plot_or(lr)
+  })
 
-    # diabetes lr model
+  # diabetes lr model
+  testthat::expect_silent({
     lr <- readRDS(file = testthat::test_path('test_data', 'lr_diabetes.Rds'))
     plotor::plot_or(lr)
+  })
 
-    # infertility lr model
+  # infertility lr model
+  testthat::expect_silent({
     lr <- readRDS(file = testthat::test_path('test_data', 'lr_infert.Rds'))
     plotor::plot_or(lr)
-
   })
+
 })
 
 testthat::test_that("table_or() does not produce messages or warnings", {
-  testthat::expect_silent({
 
-    # titanic lr model
+  # titanic lr model
+  testthat::expect_silent({
     lr <- readRDS(file = testthat::test_path('test_data', 'lr_titanic.Rds'))
     plotor::table_or(lr)
+  })
 
-    # diabetes lr model
+  # diabetes lr model
+  testthat::expect_silent({
     lr <- readRDS(file = testthat::test_path('test_data', 'lr_diabetes.Rds'))
     plotor::table_or(lr)
+  })
 
-    # infertility lr model
+  # infertility lr model
+  testthat::expect_silent({
     lr <- readRDS(file = testthat::test_path('test_data', 'lr_infert.Rds'))
     plotor::table_or(lr)
-
   })
+
+})
+
+## snapshots -------
+testthat::test_that("table_or() produces output equivalent to a snapshot", {
+
+  # titanic lr model
+  testthat::expect_snapshot({
+    lr <- readRDS(file = testthat::test_path('test_data', 'lr_titanic.Rds'))
+    plotor::table_or(lr)
+  },
+  cran = FALSE)
+})
+
+testthat::test_that("plot_or() produces plots equivalent to a snapshot", {
+
+  # titanic lr model
+  vdiffr::expect_doppelganger({
+    lr <- readRDS(file = testthat::test_path('test_data', 'lr_titanic.Rds'))
+    plotor::plot_or(lr)
+  },
+  title = "plot_titanic", cran = FALSE)
+
+  # diabetes lr model
+  vdiffr::expect_doppelganger({
+    lr <- readRDS(file = testthat::test_path('test_data', 'lr_diabetes.Rds'))
+    plotor::plot_or(lr)
+  }, title = "plot_diabetes", cran = FALSE)
+
+  # infertility lr model
+  vdiffr::expect_doppelganger({
+    lr <- readRDS(file = testthat::test_path('test_data', 'lr_infert.Rds'))
+    plotor::plot_or(lr)
+  }, title = "plot_infert", cran = FALSE)
+})
+
+testthat::test_that("table_or() produces {gt} tables equivalent to a snapshot", {
+
+  # titanic lr model
+  testthat::expect_snapshot({
+    lr <- readRDS(file = testthat::test_path('test_data', 'lr_titanic.Rds'))
+    plotor::table_or(lr, output = 'gt')
+  }, cran = FALSE)
+
+  # diabetes lr model
+  testthat::expect_snapshot({
+    lr <- readRDS(file = testthat::test_path('test_data', 'lr_diabetes.Rds'))
+    plotor::table_or(lr, output = 'gt')
+  }, cran = FALSE)
+
+  # infertility lr model
+  testthat::expect_snapshot({
+    lr <- readRDS(file = testthat::test_path('test_data', 'lr_infert.Rds'))
+    plotor::table_or(lr, output = 'gt')
+  }, cran = FALSE)
+
+})
+
+## test failure -----
+
+testthat::test_that("table_or() and plot_or() handle issues gracefully", {
+
+  # not a binomial glm model
+  testthat::expect_error({
+    lr <- readRDS(file = testthat::test_path('test_data', 'nonlr_streptb.Rds'))
+    plotor::plot_or(lr)
+  })
+  testthat::expect_error({
+    lr <- readRDS(file = testthat::test_path('test_data', 'nonlr_streptb.Rds'))
+    plotor::table_or(lr)
+  })
+
+  # non-valid conf_level
+  testthat::expect_error({
+    lr <- readRDS(file = testthat::test_path('test_data', 'lr_titanic.Rds'))
+    plotor::plot_or(lr, conf_level = "95")
+  })
+  testthat::expect_error({
+    lr <- readRDS(file = testthat::test_path('test_data', 'lr_titanic.Rds'))
+    plotor::table_or(lr, conf_level = "95")
+  })
+
+  # non-valid output type requested
+  testthat::expect_error({
+    lr <- readRDS(file = testthat::test_path('test_data', 'lr_titanic.Rds'))
+    plotor::table_or(lr, output = "pink_elephant")
+  })
+
 })
 
 # validation functions ---------------------------------------------------------
@@ -49,10 +146,10 @@ testthat::test_that("validate_conf_level_input() works as expected", {
   testthat::expect_equal(plotor:::validate_conf_level_input(0.99), 0.99)
 
   # inputs outside expected range - parse to valid inputs
-  # testthat::expect_equal(plotor:::validate_conf_level_input(80), 0.80)
-  # testthat::expect_equal(plotor:::validate_conf_level_input(95), 0.95)
-  # testthat::expect_equal(plotor:::validate_conf_level_input(99), 0.99)
-  # testthat::expect_equal(plotor:::validate_conf_level_input(99.9), 0.999)
+  testthat::expect_equal(plotor:::validate_conf_level_input(80), 0.80)
+  testthat::expect_equal(plotor:::validate_conf_level_input(95), 0.95)
+  testthat::expect_equal(plotor:::validate_conf_level_input(99), 0.99)
+  testthat::expect_equal(plotor:::validate_conf_level_input(99.9), 0.999)
 
   # inputs outside expected range - expect messages informing of the change
   testthat::expect_message(plotor:::validate_conf_level_input(-1))


### PR DESCRIPTION
closes #36 
closes #35 

# Test suite development
This PR continues development of the test suite and addresses issues {tidyselect} warnings uncovered when testing.

Tests introduced:

- {vdiffr} based tests on plot outputs from `plot_or()`,
- snapshot-based tests on outputs from `table_or()`,
- tests designed to elicit warning messages by passing invalid parameters