### PR TITLE
10 estimate confidence intervals quickly

### DIFF
--- a/man/plot_or.Rd
+++ b/man/plot_or.Rd
@@ -4,12 +4,14 @@
 \alias{plot_or}
 \title{Plot OR}
 \usage{
-plot_or(glm_model_results, conf_level = 0.95)
+plot_or(glm_model_results, conf_level = 0.95, confint_fast_estimate = FALSE)
 }
 \arguments{
 \item{glm_model_results}{Results from a binomial Generalised Linear Model (GLM), as produced by \code{\link[stats:glm]{stats::glm()}}.}
 
 \item{conf_level}{Numeric between 0.001 and 0.999 (default = 0.95). The confidence level to use when setting the confidence interval, most commonly will be 0.95 or 0.99 but can be set otherwise.}
+
+\item{confint_fast_estimate}{Boolean (default = \code{FALSE}) Should a faster estimate of the confidence interval be used? IMPORTANT, setting this to \code{TRUE} assumes normally distributed data, which may not be appropriate for your data.}
 }
 \value{
 an object of class \code{gg} and \code{ggplot}

--- a/man/table_or.Rd
+++ b/man/table_or.Rd
@@ -4,7 +4,12 @@
 \alias{table_or}
 \title{Table OR}
 \usage{
-table_or(glm_model_results, conf_level = 0.95, output = "tibble")
+table_or(
+  glm_model_results,
+  conf_level = 0.95,
+  output = "tibble",
+  confint_fast_estimate = FALSE
+)
 }
 \arguments{
 \item{glm_model_results}{Results from a binomial Generalised Linear Model (GLM), as produced by \code{\link[stats:glm]{stats::glm()}}.}
@@ -12,6 +17,8 @@ table_or(glm_model_results, conf_level = 0.95, output = "tibble")
 \item{conf_level}{Numeric between 0.001 and 0.999 (default = 0.95). The confidence level to use when setting the confidence interval, most commonly will be 0.95 or 0.99 but can be set otherwise.}
 
 \item{output}{String description of the output type. Default = 'tibble'. Options include 'tibble' and 'gt'.}
+
+\item{confint_fast_estimate}{Boolean (default = \code{FALSE}) Should a faster estimate of the confidence interval be used? IMPORTANT, setting this to \code{TRUE} assumes normally distributed data, which may not be appropriate for your data.}
 }
 \value{
 object returned depends on \code{output} parameter - output = 'tibble' returns an object of "tbl_df", "tbl", "data.frame" class, whilst output = 'gt' returns an object of class "gt_tbl" and "list".


### PR DESCRIPTION
closes #10 

# Optional faster way to estimate confidence intervals
This PR introduces an optional way to estimate confidence intervals using `stats::confint.default()`.

The benefit of this change is to allow for faster calculation of confidence intervals, especially for large datasets (around 100k records or more), where the `stats::confint` method for estimating confidence intervals in glm models can take much longer.

While `stats::confint.default` can be used to estimate confidence intervals for a logistic regression model, it is not the most recommended approach.

`stats::confint.default` is a general-purpose function that computes confidence intervals based on the normal distribution, which is an approximation that may not always be accurate, especially for logistic regression models where the response variable is binary.

For logistic regression models, it is generally recommended to use `stats::confint` which is specifically designed to handle the logistic regression case. This function uses the profile likelihood method to compute confidence intervals, which is a more accurate and reliable approach.

The profile likelihood method takes into account the non-linear nature of the logistic regression model and provides a more accurate estimate of the confidence intervals.

Testing on the Titanic dataset indicates small but perceptible changes to the confidence intervals:

```
test1 <- plotor::table_or(
  glm_model_results = lr_titanic,
  conf_level = 0.95,
  confint_fast_estimate = FALSE
)

test2 <- plotor::table_or(
  glm_model_results = lr_titanic,
  conf_level = 0.95,
  confint_fast_estimate = TRUE
)

test1 |> 
  dplyr::select(label, level, estimate, p.value, conf.low, conf.high, significance)
# A tibble: 8 × 7
  label           level  estimate   p.value conf.low conf.high significance
  <fct>           <fct>     <dbl>     <dbl>    <dbl>     <dbl> <chr>       
1 Passenger class 3rd       0.169  3.69e-25    0.120     0.236 Significant 
2 Passenger class 1st      NA     NA          NA        NA     Comparator  
3 Passenger class 2nd       0.361  2.05e- 7    0.245     0.529 Significant 
4 Passenger class Crew      0.424  5.00e- 8    0.312     0.577 Significant 
5 Gender          Male     NA     NA          NA        NA     Comparator  
6 Gender          Female   11.2    1.43e-66    8.57     14.9   Significant 
7 Age at death    Child     2.89   1.36e- 5    1.79      4.67  Significant 
8 Age at death    Adult    NA     NA          NA        NA     Comparator  

test2 |> 
  dplyr::select(label, level, estimate, p.value, conf.low, conf.high, significance)
# A tibble: 8 × 7
  label           level  estimate   p.value conf.low conf.high significance
  <fct>           <fct>     <dbl>     <dbl>    <dbl>     <dbl> <chr>       
1 Passenger class 3rd       0.169  3.69e-25    0.121     0.237 Significant 
2 Passenger class 1st      NA     NA          NA        NA     Comparator  
3 Passenger class 2nd       0.361  2.05e- 7    0.246     0.530 Significant 
4 Passenger class Crew      0.424  5.00e- 8    0.312     0.577 Significant 
5 Gender          Male     NA     NA          NA        NA     Comparator  
6 Gender          Female   11.2    1.43e-66    8.54     14.8   Significant 
7 Age at death    Child     2.89   1.36e- 5    1.79      4.66  Significant 
8 Age at death    Adult    NA     NA          NA        NA     Comparator  
```

Differences between the two results indicate changes on the order of the third decimal place. For example, Passenger class `3rd` has a confidence interval of 0.120 to 0.236 using the correct profile likelihood approach, which changes to 0.121 to 0.237 using the faster estimate.
