### PR TITLE
60 improve cli feedback

### DIFF
--- a/tests/testthat/test_data/make_test_data.R
+++ b/tests/testthat/test_data/make_test_data.R
@@ -358,6 +358,16 @@ get_lr_separated <- function() {
   )
 }
 
+get_lr_separated_quasi <- function() {
+  df <- get_df_separated()
+  lr <-
+    stats::glm(
+      data = df,
+      formula = outcome ~ pred1 + pred3,
+      family = 'binomial'
+    )
+}
+
 # Get data ---------------------------------------------------------------------
 # df
 df_titanic <- get_df_titanic()


### PR DESCRIPTION
closes #60 

# Feedback following failed checks has been improved
This PR improves the structure and formatting of user feedback when one or more assumption checks fail.

The changes include:

- **Adding h1 headings for each assumption**. This will help to disambiguate feedback for the user when more than one assumption check fails.
- **Adding h3 subheadings to separate feedback content**. Depending on the amount of feedback and whether multi-step checks are done, it may increase clarity of the feedback to add in subheadings.
- **Providing general advice**. Providing brief explanation for why the assumption is important to logistical regression models and any other relevant details, such as parameter values, can be helpful to the user when they have requested detailed feedback. These are in their own section with h3 subheading titled 'About'.
- Feedback text to be given using cli::cli_alert_info() formatting.