### PR TITLE
Responding to {ggplot2} v3.5.2.9001

### DIFF
--- a/R/gt_extras.R
+++ b/R/gt_extras.R
@@ -1,0 +1,384 @@
+#' Plot a confidence interval around a point
+#'
+#' @param gt_object An existing gt table
+#' @param column The column that contains the mean of the sample. This can either be a single number per row, if you have calculated the values ahead of time, or a list of values if you want to calculate the confidence intervals.
+#' @param ci_columns Optional columns representing the left/right confidence intervals of your sample.
+#' @param ci The confidence interval, representing the percentage, ie `0.9` which represents `10-90` for the two tails.
+#' @param palette A vector of color strings of exactly length 4. The colors represent the central point, the color of the range, the color of the stroke around the central point, and the color of the text, in that specific order.
+#' @param width A number indicating the width of the plot in `"mm"`, defaults to `45`.
+#' @param text_args A list of named arguments. Optional text arguments passed as a list to `scales::label_number`.
+#' @param text_size A number indicating the size of the text indicators in the plot. Defaults to 1.5. Can also be set to `0` to "remove" the text itself.
+#' @param ref_line A number indicating where to place reference line on x-axis.
+#'
+#' @return a gt table
+#' @export
+#'
+#' @section Examples:
+#' ```r
+#' # gtExtras can calculate basic conf int
+#' # using confint() function
+#'
+#' ci_table <- generate_df(
+#'   n = 50, n_grps = 3,
+#'   mean = c(10, 15, 20), sd = c(10, 10, 10),
+#'   with_seed = 37
+#' ) %>%
+#'   dplyr::group_by(grp) %>%
+#'   dplyr::summarise(
+#'     n = dplyr::n(),
+#'     avg = mean(values),
+#'     sd = sd(values),
+#'     list_data = list(values)
+#'   ) %>%
+#'   gt::gt() %>%
+#'   gt_plt_conf_int(list_data, ci = 0.9)
+#'
+#' # You can also provide your own values
+#' # based on your own algorithm/calculations
+#' pre_calc_ci_tab <- dplyr::tibble(
+#'   mean = c(12, 10), ci1 = c(8, 5), ci2 = c(16, 15),
+#'   ci_plot = c(12, 10)
+#' ) %>%
+#'   gt::gt() %>%
+#'   gt_plt_conf_int(
+#'     ci_plot, c(ci1, ci2),
+#'     palette = c("red", "lightgrey", "black", "red")
+#'     )
+#' ```
+#' @section Figures:
+#' \if{html}{\figure{gt_plt_ci_calc.png}{options: width=70\%}}
+#' \if{html}{\figure{gt_plt_ci_vals.png}{options: width=70\%}}
+#'
+#' @family Themes
+#' @section Function ID:
+#' 3-10
+gt_plt_conf_int_new <- function(gt_object,
+                            column,
+                            ci_columns,
+                            ci = 0.9,
+                            ref_line = NULL,
+                            palette = c("black", "grey", "white", "black"),
+                            width = 45,
+                            text_args = list(accuracy = 1),
+                            text_size = 1.5) {
+  all_vals <- gt_index(gt_object, {{ column }}, as_vector = FALSE)
+
+  stopifnot("Confidence level must be between 0 and 1" = dplyr::between(ci, 0, 1))
+  # convert desired confidence interval from percentage
+  # to a two-tailed level to be used in confint() function
+  level <- 1 - ((1 - ci) * 2)
+
+  # if user doesn't supply their own pre-defined columns
+  # grab them or save as "none"
+  if (!missing(ci_columns)) {
+    ci_vals <- all_vals %>%
+      dplyr::select({{ ci_columns }})
+
+    ci_val1 <- ci_vals[[1]]
+    ci_val2 <- ci_vals[[2]]
+  } else {
+    ci_val1 <- "none"
+  }
+
+  column_vals <- all_vals %>%
+    dplyr::select({{ column }}) %>%
+    dplyr::pull()
+
+  if ("none" %in% ci_val1) {
+    stopifnot(
+      "Must provide list column if no defined Confidence Intervals" =
+        (class(column_vals) %in% c("list"))
+    )
+
+    # create a list of dataframes with
+    # roughly calculated confidence intervals
+    data_in <- lapply(column_vals, function(x) {
+      dplyr::tibble(x = stats::na.omit(x), y = "1a") %>%
+        dplyr::summarise(
+          mean = mean(.data$x, na.rm = TRUE),
+          y = unique(.data$y, na.rm = TRUE),
+          lm_out = list(stats::lm(x ~ 1)),
+          ci = list(stats::confint(.data$lm_out[[1]], level = level)),
+          ci1 = ci[[1]][1],
+          ci2 = ci[[1]][2]
+        ) %>%
+        dplyr::mutate(y = "1a")
+    })
+  } else {
+    stopifnot(
+      "Must provide single values per row if defining Confidence Intervals" =
+        !(class(column_vals) %in% "list")
+    )
+
+    data_in <- dplyr::tibble(mean = column_vals, y = "1a") %>%
+      dplyr::mutate(
+        ci1 = ci_val1,
+        ci2 = ci_val2,
+        row_n = dplyr::row_number()
+      ) %>%
+      split(.$row_n)
+  }
+
+  # calculate the total range so the x-axis can be shared across rows
+  all_ci_min <- min(dplyr::bind_rows(data_in)$ci1, na.rm = TRUE)
+  all_ci_max <- max(dplyr::bind_rows(data_in)$ci2, na.rm = TRUE)
+
+  ext_range <- scales::expand_range(
+    c(all_ci_min, all_ci_max),
+    mul = 0.1,
+    zero_width = 1
+  )
+
+  ref_line <- if (is.null(ref_line)) {
+    list("none")
+  } else {
+    list(ref_line)
+  }
+
+  gt_object %>%
+    gt::text_transform(
+      locations = gt::cells_body(columns = {{ column }}),
+      fn = function(x) {
+        tab_built <- mapply(
+          FUN = add_ci_plot,
+          data_in,
+          list(palette),
+          width,
+          list(ext_range),
+          list(text_args),
+          text_size,
+          list(ref_line),
+          SIMPLIFY = FALSE
+        )
+
+        tab_built
+      }
+    ) %>%
+    gt::cols_align(align = "left", columns = {{ column }})
+}
+
+
+
+#' Add a confidence interval plot inside a specific row
+#'
+#' @param data_in A dataframe of length 1
+#' @param pal_vals A length 4 palette to be used for coloring points, segments and text
+#' @param width Width of the output plot in `'mm'`
+#' @param ext_range A length two vector of the full range across all values
+#' @param text_args A list of optional text arguments passed to `scales::label_number()`
+#' @inheritParams gt_plt_conf_int
+#' @noRd
+#'
+#' @return SVG/HTML
+add_ci_plot <- function(data_in,
+                        pal_vals,
+                        width,
+                        ext_range,
+                        text_args = list(scale_cut = cut_short_scale()),
+                        text_size,
+                        ref_line) {
+  if (NA %in% unlist(data_in)) {
+    return("&nbsp;")
+  }
+
+  if (unlist(ref_line) == "none") {
+    base_plot <- data_in %>%
+      ggplot2::ggplot(ggplot2::aes(x = .data$mean, y = "1a"))
+  } else {
+    base_plot <- data_in %>%
+      ggplot2::ggplot(ggplot2::aes(x = .data$mean, y = "1a")) +
+      ggplot2::geom_text(
+        ggplot2::aes(
+          x = unlist(ref_line) * 1.01,
+          label = do.call(scales::label_number, text_args)(unlist(ref_line))
+        ),
+        color = pal_vals[4],
+        vjust = 1.1,
+        size = text_size,
+        hjust = 0,
+        position = ggplot2::position_nudge(y = -0.25),
+        family = "mono",
+        fontface = "bold"
+      ) +
+      ggplot2::geom_vline(xintercept = ref_line[[1]], color = pal_vals[4])
+  }
+
+  plot_out <- base_plot +
+    ggplot2::geom_segment(
+      ggplot2::aes(x = .data$ci1, xend = .data$ci2, y = .data$y, yend = .data$y),
+      lineend = "round",
+      linewidth = 1,
+      color = pal_vals[2],
+      alpha = 0.75
+    ) +
+    ggplot2::geom_point(
+      ggplot2::aes(x = .data$mean, y = .data$y),
+      size = 2,
+      shape = 21,
+      fill = pal_vals[1],
+      color = pal_vals[3],
+      stroke = 0.75
+    ) +
+    ggplot2::geom_label(
+      ggplot2::aes(
+        x = .data$ci2,
+        label = do.call(scales::label_number, text_args)(.data$ci2)
+      ),
+      color = pal_vals[4],
+      hjust = 1.1,
+      size = text_size,
+      vjust = 0,
+      fill = "transparent",
+      position = ggplot2::position_nudge(y = 0.25),
+      family = "mono",
+      fontface = "bold",
+      linewidth = 0,
+      label.padding = ggplot2::unit(0.05, "lines"),
+      label.r = ggplot2::unit(0, "lines")
+    ) +
+    # ggplot2::geom_label(
+    #   ggplot2::aes(x = .data$ci1, label = do.call(scales::label_number, text_args)(.data$ci1)),
+    #   position = ggplot2::position_nudge(y = 0.25),
+    #   color = pal_vals[4],
+    #   hjust = -0.1,
+    #   size = text_size,
+    #   vjust = 0,
+    #   fill = "transparent",
+    #   family = "mono",
+    #   fontface = "bold",
+    #   linewidth = ggplot2::unit(0, "lines"),
+    #   #label.size = ggplot2::unit(0, "lines"),
+    #   label.padding = ggplot2::unit(0.05, "lines"),
+    #   label.r = ggplot2::unit(0, "lines")
+    # ) +
+    ggplot2::theme_void() +
+    ggplot2::theme(
+      legend.position = "none",
+      plot.margin = ggplot2::margin(0, 0, 0, 0, "pt"),
+      plot.background = ggplot2::element_blank(),
+      panel.background = ggplot2::element_blank()
+    ) +
+    ggplot2::coord_cartesian(ylim = c(0.9, 1.5), xlim = ext_range)
+
+  out_name <- file.path(tempfile(
+    pattern = "file",
+    tmpdir = tempdir(),
+    fileext = ".svg"
+  ))
+
+  ggplot2::ggsave(
+    out_name,
+    plot = plot_out,
+    dpi = 25.4,
+    height = 5,
+    width = width,
+    units = "mm",
+    device = "svg"
+  )
+
+  img_plot <- readLines(out_name) %>%
+    paste0(collapse = "") %>%
+    gt::html()
+
+  on.exit(file.remove(out_name), add = TRUE)
+
+  img_plot
+}
+
+
+#' Return the underlying data, arranged by the internal index
+#' @description This is a utility function to extract the underlying data from
+#' a `gt` table. You can use it with a saved `gt` table, in the pipe (`%>%`)
+#' or even within most other `gt` functions (eg `tab_style()`). It defaults to
+#' returning the column indicated as a vector, so that you can work with the
+#' values. Typically this is used with logical statements to affect one column
+#' based on the values in that specified secondary column.
+#' Alternatively, you can extract the entire ordered data according to the
+#' internal index as a `tibble`. This allows for even more complex steps
+#' based on multiple indices.
+#'
+#' @param gt_object An existing gt table object
+#' @param column The column name that you intend to extract, accepts tidyeval semantics (ie `mpg` instead of `"mpg"`)
+#' @param as_vector A logical indicating whether you'd like just the column indicated as a vector, or the entire dataframe
+#' @return A vector or a `tibble`
+#' @export
+#'
+#' @examples
+#' library(gt)
+#'
+#' # This is a key step, as gt will create the row groups
+#' # based on first observation of the unique row items
+#' # this sampling will return a row-group order for cyl of 6,4,8
+#'
+#' set.seed(1234)
+#' sliced_data <- mtcars %>%
+#'   dplyr::group_by(cyl) %>%
+#'   dplyr::slice_head(n = 3) %>%
+#'   dplyr::ungroup() %>%
+#'   # randomize the order
+#'   dplyr::slice_sample(n = 9)
+#'
+#' # not in "order" yet
+#' sliced_data$cyl
+#'
+#' # But unique order of 6,4,8
+#' unique(sliced_data$cyl)
+#'
+#' # creating a standalone basic table
+#' test_tab <- sliced_data %>%
+#'   gt(groupname_col = "cyl")
+#'
+#' # can style a specific column based on the contents of another column
+#' tab_out_styled <- test_tab %>%
+#'   tab_style(
+#'     locations = cells_body(mpg, rows = gt_index(., am) == 0),
+#'     style = cell_fill("red")
+#'   )
+#'
+#' # OR can extract the underlying data in the "correct order"
+#' # according to the internal gt structure, ie arranged by group
+#' # by cylinder, 6,4,8
+#' gt_index(test_tab, mpg, as_vector = FALSE)
+#'
+#' # note that the order of the index data is
+#' # not equivalent to the order of the input data
+#' # however all the of the rows still match
+#' sliced_data
+#' @section Figures:
+#' \if{html}{\figure{gt_index_style.png}{options: width=50\%}}
+#'
+#' @family Utilities
+#' @section Function ID:
+#' 2-20
+
+gt_index <- function(gt_object, column, as_vector = TRUE) {
+  stopifnot("'gt_object' must be a 'gt_tbl', have you accidentally passed raw data?" = "gt_tbl" %in% class(gt_object))
+  stopifnot("'as_vector' must be a TRUE or FALSE" = is.logical(as_vector))
+
+  if (length(gt_object[["_row_groups"]]) >= 1) {
+    # if the data is grouped you need to identify the group column
+    # and arrange by that column. I convert to a factor so that the
+    # columns don't default to arrange by other defaults
+    #  (ie alphabetical or numerical)
+    gt_row_grps <- gt_object[["_row_groups"]]
+
+    grp_vec_ord <- gt_object[["_stub_df"]] %>%
+      dplyr::mutate(group_id = factor(group_id, levels = gt_row_grps)) %>%
+      dplyr::arrange(group_id) %>%
+      dplyr::pull(rownum_i)
+
+    df_ordered <- gt_object[["_data"]] %>%
+      dplyr::slice(grp_vec_ord)
+  } else {
+    # if the data is not grouped, then it will just "work"
+    df_ordered <- gt_object[["_data"]]
+  }
+
+  # return as vector or tibble in correct, gt-indexed ordered
+  if (isTRUE(as_vector)) {
+    df_ordered %>%
+      dplyr::pull({{ column }})
+  } else {
+    df_ordered
+  }
+}

--- a/R/plot_or.R
+++ b/R/plot_or.R
@@ -442,7 +442,7 @@ summarise_rows_per_variable_in_model <- function(model_results) {
   # combine the two data
   df <-
     df |>
-    dplyr::select(.data$term) |>
+    dplyr::select(dplyr::any_of("term")) |>
     dplyr::left_join(
       y = df_rows,
       by = dplyr::join_by('term' == 'term')
@@ -584,11 +584,12 @@ plot_odds_ratio <- function(df, model, conf_level) {
       ggplot2::aes(size = .data$rows_scale),
       shape = 15
     ) +
-    ggplot2::geom_errorbarh(
+    ggplot2::geom_errorbar(
       # remove any confidence estimates with NA values
       data = df |> dplyr::filter(!is.na(.data$conf.high), !is.na(.data$conf.low)),
       ggplot2::aes(xmax = .data$conf.high, xmin = .data$conf.low),
-      height = 1 / 5
+      width = 1 / 5,
+      na.rm = TRUE
     ) +
     ggplot2::scale_x_log10(n.breaks = 10, labels = scales::comma) +
     ggplot2::theme_minimal() +
@@ -990,7 +991,13 @@ output_gt <- function(df, conf_level, title = "Odds Ratio Summary Table") {
       "))
     ) |>
     # add an OR plot to visualise the results
-    gtExtras::gt_plt_conf_int(
+    # gtExtras::gt_plt_conf_int(
+    #   column = 'plot_or',
+    #   ci_columns = c('plot_ci_l', 'plot_ci_u'),
+    #   ref_line = 0,
+    #   text_size = 0
+    # ) |>
+    gt_plt_conf_int_new(
       column = 'plot_or',
       ci_columns = c('plot_ci_l', 'plot_ci_u'),
       ref_line = 0,
@@ -1569,13 +1576,14 @@ assumption_sample_size <- function(glm, min_events_per_predictor = 10, details =
             ) |>
             # rename var to level and move predictor to start of tibble
             dplyr::rename(level = {{.var}}) |>
-            dplyr::relocate(.data$predictor, .before = .data$level) |>
+            dplyr::relocate("predictor", .before = "level") |>
             # sort by count (in case this needs displaying)
             dplyr::arrange(dplyr::desc(.data$n)) |>
             # pivot outcomes to their own columns
             tidyr::pivot_wider(
               names_from = dplyr::any_of("outcome"),
-              values_from = .data$n
+              #values_from = .data$n
+              values_from = "n"
             )
         }
       )

--- a/tests/testthat/_snaps/plot_or/plot-diabetes.svg
+++ b/tests/testthat/_snaps/plot_or/plot-diabetes.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMjc1LjAzfDcxNC41MnwzOC4xMnwxMTAuNTQ='>
@@ -195,86 +196,149 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNjcuNzl8MzguMTJ8MTEwLjU0'>
-    <rect x='5.48' y='38.12' width='162.31' height='72.43' />
+  <clipPath id='cpNS40OHw4Ni42NHwzOC4xMnwxMTAuNTQ='>
+    <rect x='5.48' y='38.12' width='81.16' height='72.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNjcuNzl8MzguMTJ8MTEwLjU0)'>
+<g clip-path='url(#cpNS40OHw4Ni42NHwzOC4xMnwxMTAuNTQ=)'>
 <text x='82.25' y='77.36' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='45.49px' lengthAdjust='spacingAndGlyphs'>Age (years)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNjR8MTY3Ljc5fDM4LjEyfDExMC41NA=='>
+    <rect x='86.64' y='38.12' width='81.16' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNjR8MTY3Ljc5fDM4LjEyfDExMC41NA==)'>
 <text x='163.41' y='77.36' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>age</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNjcuNzl8MTEwLjU0fDE4Mi45Nw=='>
-    <rect x='5.48' y='110.54' width='162.31' height='72.43' />
+  <clipPath id='cpNS40OHw4Ni42NHwxMTAuNTR8MTgyLjk3'>
+    <rect x='5.48' y='110.54' width='81.16' height='72.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNjcuNzl8MTEwLjU0fDE4Mi45Nw==)'>
+<g clip-path='url(#cpNS40OHw4Ni42NHwxMTAuNTR8MTgyLjk3)'>
 <text x='82.25' y='149.79' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='67.03px' lengthAdjust='spacingAndGlyphs'>Body mass index</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNjR8MTY3Ljc5fDExMC41NHwxODIuOTc='>
+    <rect x='86.64' y='110.54' width='81.16' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNjR8MTY3Ljc5fDExMC41NHwxODIuOTc=)'>
 <text x='163.41' y='149.79' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='14.18px' lengthAdjust='spacingAndGlyphs'>bmi</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNjcuNzl8MTgyLjk3fDI1NS40MA=='>
-    <rect x='5.48' y='182.97' width='162.31' height='72.43' />
+  <clipPath id='cpNS40OHw4Ni42NHwxODIuOTd8MjU1LjQw'>
+    <rect x='5.48' y='182.97' width='81.16' height='72.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNjcuNzl8MTgyLjk3fDI1NS40MA==)'>
+<g clip-path='url(#cpNS40OHw4Ni42NHwxODIuOTd8MjU1LjQw)'>
 <text x='82.25' y='217.46' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='41.09px' lengthAdjust='spacingAndGlyphs'>Number of</text>
 <text x='82.25' y='226.97' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='47.95px' lengthAdjust='spacingAndGlyphs'>pregnancies</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNjR8MTY3Ljc5fDE4Mi45N3wyNTUuNDA='>
+    <rect x='86.64' y='182.97' width='81.16' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNjR8MTY3Ljc5fDE4Mi45N3wyNTUuNDA=)'>
 <text x='163.41' y='222.21' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='63.12px' lengthAdjust='spacingAndGlyphs'>pregnancy_num</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNjcuNzl8MjU1LjQwfDMyNy44Mw=='>
-    <rect x='5.48' y='255.40' width='162.31' height='72.43' />
+  <clipPath id='cpNS40OHw4Ni42NHwyNTUuNDB8MzI3Ljgz'>
+    <rect x='5.48' y='255.40' width='81.16' height='72.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNjcuNzl8MjU1LjQwfDMyNy44Mw==)'>
+<g clip-path='url(#cpNS40OHw4Ni42NHwyNTUuNDB8MzI3Ljgz)'>
 <text x='82.25' y='285.14' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='62.14px' lengthAdjust='spacingAndGlyphs'>Plasma glucose</text>
 <text x='82.25' y='294.64' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='52.84px' lengthAdjust='spacingAndGlyphs'>concentration</text>
 <text x='82.25' y='304.15' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='42.55px' lengthAdjust='spacingAndGlyphs'>(mg per dl)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNjR8MTY3Ljc5fDI1NS40MHwzMjcuODM='>
+    <rect x='86.64' y='255.40' width='81.16' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNjR8MTY3Ljc5fDI1NS40MHwzMjcuODM=)'>
 <text x='163.41' y='294.64' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='59.20px' lengthAdjust='spacingAndGlyphs'>glucose_mg_dl</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNjcuNzl8MzI3LjgzfDQwMC4yNg=='>
-    <rect x='5.48' y='327.83' width='162.31' height='72.43' />
+  <clipPath id='cpNS40OHw4Ni42NHwzMjcuODN8NDAwLjI2'>
+    <rect x='5.48' y='327.83' width='81.16' height='72.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNjcuNzl8MzI3LjgzfDQwMC4yNg==)'>
+<g clip-path='url(#cpNS40OHw4Ni42NHwzMjcuODN8NDAwLjI2)'>
 <text x='82.25' y='362.32' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='57.24px' lengthAdjust='spacingAndGlyphs'>Diastolic blood</text>
 <text x='82.25' y='371.82' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='68.47px' lengthAdjust='spacingAndGlyphs'>pressure (mmHg)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNjR8MTY3Ljc5fDMyNy44M3w0MDAuMjY='>
+    <rect x='86.64' y='327.83' width='81.16' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNjR8MTY3Ljc5fDMyNy44M3w0MDAuMjY=)'>
 <text x='163.41' y='367.07' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='48.93px' lengthAdjust='spacingAndGlyphs'>dbp_mm_hg</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNjcuNzl8NDAwLjI2fDQ3Mi42OA=='>
-    <rect x='5.48' y='400.26' width='162.31' height='72.43' />
+  <clipPath id='cpNS40OHw4Ni42NHw0MDAuMjZ8NDcyLjY4'>
+    <rect x='5.48' y='400.26' width='81.16' height='72.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNjcuNzl8NDAwLjI2fDQ3Mi42OA==)'>
+<g clip-path='url(#cpNS40OHw4Ni42NHw0MDAuMjZ8NDcyLjY4)'>
 <text x='82.25' y='429.99' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='46.96px' lengthAdjust='spacingAndGlyphs'>Triceps skin</text>
 <text x='82.25' y='439.50' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.33px' lengthAdjust='spacingAndGlyphs'>fold thickness</text>
 <text x='82.25' y='449.00' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='20.53px' lengthAdjust='spacingAndGlyphs'>(mm)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNjR8MTY3Ljc5fDQwMC4yNnw0NzIuNjg='>
+    <rect x='86.64' y='400.26' width='81.16' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNjR8MTY3Ljc5fDQwMC4yNnw0NzIuNjg=)'>
 <text x='163.41' y='439.50' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='45.49px' lengthAdjust='spacingAndGlyphs'>triceps_mm</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNjcuNzl8NDcyLjY4fDU0NS4xMQ=='>
-    <rect x='5.48' y='472.68' width='162.31' height='72.43' />
+  <clipPath id='cpNS40OHw4Ni42NHw0NzIuNjh8NTQ1LjEx'>
+    <rect x='5.48' y='472.68' width='81.16' height='72.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNjcuNzl8NDcyLjY4fDU0NS4xMQ==)'>
+<g clip-path='url(#cpNS40OHw4Ni42NHw0NzIuNjh8NTQ1LjEx)'>
 <text x='82.25' y='502.42' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='53.32px' lengthAdjust='spacingAndGlyphs'>Serum insulin</text>
 <text x='82.25' y='511.93' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='48.41px' lengthAdjust='spacingAndGlyphs'>(microIU per</text>
 <text x='82.25' y='521.43' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>ml)</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNjR8MTY3Ljc5fDQ3Mi42OHw1NDUuMTE='>
+    <rect x='86.64' y='472.68' width='81.16' height='72.43' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNjR8MTY3Ljc5fDQ3Mi42OHw1NDUuMTE=)'>
 <text x='163.41' y='511.93' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='72.39px' lengthAdjust='spacingAndGlyphs'>insulin_microiu_ml</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>

--- a/tests/testthat/_snaps/plot_or/plot-titanic.svg
+++ b/tests/testthat/_snaps/plot_or/plot-titanic.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMjY5LjIxfDcxNC41MnwzOC4xMnwxMDEuNDk='>
@@ -203,84 +204,156 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNTIuMTh8MzguMTJ8MTAxLjQ5'>
-    <rect x='5.48' y='38.12' width='146.70' height='63.37' />
+  <clipPath id='cpNS40OHw3OC44M3wzOC4xMnwxMDEuNDk='>
+    <rect x='5.48' y='38.12' width='73.35' height='63.37' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNTIuMTh8MzguMTJ8MTAxLjQ5)'>
+<g clip-path='url(#cpNS40OHw3OC44M3wzOC4xMnwxMDEuNDk=)'>
 <text x='74.45' y='72.83' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='64.58px' lengthAdjust='spacingAndGlyphs'>Passenger class</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzguODN8MTUyLjE4fDM4LjEyfDEwMS40OQ=='>
+    <rect x='78.83' y='38.12' width='73.35' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzguODN8MTUyLjE4fDM4LjEyfDEwMS40OQ==)'>
 <text x='147.80' y='72.83' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='11.74px' lengthAdjust='spacingAndGlyphs'>1st</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNTIuMTh8MTAxLjQ5fDE2NC44Nw=='>
-    <rect x='5.48' y='101.49' width='146.70' height='63.37' />
+  <clipPath id='cpNS40OHw3OC44M3wxMDEuNDl8MTY0Ljg3'>
+    <rect x='5.48' y='101.49' width='73.35' height='63.37' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNTIuMTh8MTAxLjQ5fDE2NC44Nw==)'>
+<g clip-path='url(#cpNS40OHw3OC44M3wxMDEuNDl8MTY0Ljg3)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzguODN8MTUyLjE4fDEwMS40OXwxNjQuODc='>
+    <rect x='78.83' y='101.49' width='73.35' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzguODN8MTUyLjE4fDEwMS40OXwxNjQuODc=)'>
 <text x='147.80' y='136.21' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>2nd</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNTIuMTh8MTY0Ljg3fDIyOC4yNA=='>
-    <rect x='5.48' y='164.87' width='146.70' height='63.37' />
+  <clipPath id='cpNS40OHw3OC44M3wxNjQuODd8MjI4LjI0'>
+    <rect x='5.48' y='164.87' width='73.35' height='63.37' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNTIuMTh8MTY0Ljg3fDIyOC4yNA==)'>
+<g clip-path='url(#cpNS40OHw3OC44M3wxNjQuODd8MjI4LjI0)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzguODN8MTUyLjE4fDE2NC44N3wyMjguMjQ='>
+    <rect x='78.83' y='164.87' width='73.35' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzguODN8MTUyLjE4fDE2NC44N3wyMjguMjQ=)'>
 <text x='147.80' y='199.58' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='12.72px' lengthAdjust='spacingAndGlyphs'>3rd</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNTIuMTh8MjI4LjI0fDI5MS42MQ=='>
-    <rect x='5.48' y='228.24' width='146.70' height='63.37' />
+  <clipPath id='cpNS40OHw3OC44M3wyMjguMjR8MjkxLjYx'>
+    <rect x='5.48' y='228.24' width='73.35' height='63.37' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNTIuMTh8MjI4LjI0fDI5MS42MQ==)'>
+<g clip-path='url(#cpNS40OHw3OC44M3wyMjguMjR8MjkxLjYx)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzguODN8MTUyLjE4fDIyOC4yNHwyOTEuNjE='>
+    <rect x='78.83' y='228.24' width='73.35' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzguODN8MTUyLjE4fDIyOC4yNHwyOTEuNjE=)'>
 <text x='147.80' y='262.96' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='20.54px' lengthAdjust='spacingAndGlyphs'>Crew</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNTIuMTh8MjkxLjYxfDM1NC45OQ=='>
-    <rect x='5.48' y='291.61' width='146.70' height='63.37' />
+  <clipPath id='cpNS40OHw3OC44M3wyOTEuNjF8MzU0Ljk5'>
+    <rect x='5.48' y='291.61' width='73.35' height='63.37' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNTIuMTh8MjkxLjYxfDM1NC45OQ==)'>
+<g clip-path='url(#cpNS40OHw3OC44M3wyOTEuNjF8MzU0Ljk5)'>
 <text x='74.45' y='326.33' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='29.36px' lengthAdjust='spacingAndGlyphs'>Gender</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzguODN8MTUyLjE4fDI5MS42MXwzNTQuOTk='>
+    <rect x='78.83' y='291.61' width='73.35' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzguODN8MTUyLjE4fDI5MS42MXwzNTQuOTk=)'>
 <text x='147.80' y='326.33' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='19.08px' lengthAdjust='spacingAndGlyphs'>Male</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNTIuMTh8MzU0Ljk5fDQxOC4zNg=='>
-    <rect x='5.48' y='354.99' width='146.70' height='63.37' />
+  <clipPath id='cpNS40OHw3OC44M3wzNTQuOTl8NDE4LjM2'>
+    <rect x='5.48' y='354.99' width='73.35' height='63.37' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNTIuMTh8MzU0Ljk5fDQxOC4zNg==)'>
+<g clip-path='url(#cpNS40OHw3OC44M3wzNTQuOTl8NDE4LjM2)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzguODN8MTUyLjE4fDM1NC45OXw0MTguMzY='>
+    <rect x='78.83' y='354.99' width='73.35' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzguODN8MTUyLjE4fDM1NC45OXw0MTguMzY=)'>
 <text x='147.80' y='389.70' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>Female</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNTIuMTh8NDE4LjM2fDQ4MS43NA=='>
-    <rect x='5.48' y='418.36' width='146.70' height='63.37' />
+  <clipPath id='cpNS40OHw3OC44M3w0MTguMzZ8NDgxLjc0'>
+    <rect x='5.48' y='418.36' width='73.35' height='63.37' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNTIuMTh8NDE4LjM2fDQ4MS43NA==)'>
+<g clip-path='url(#cpNS40OHw3OC44M3w0MTguMzZ8NDgxLjc0)'>
 <text x='74.45' y='453.08' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='49.91px' lengthAdjust='spacingAndGlyphs'>Age at death</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzguODN8MTUyLjE4fDQxOC4zNnw0ODEuNzQ='>
+    <rect x='78.83' y='418.36' width='73.35' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzguODN8MTUyLjE4fDQxOC4zNnw0ODEuNzQ=)'>
 <text x='147.80' y='453.08' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>Adult</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNS40OHwxNTIuMTh8NDgxLjc0fDU0NS4xMQ=='>
-    <rect x='5.48' y='481.74' width='146.70' height='63.37' />
+  <clipPath id='cpNS40OHw3OC44M3w0ODEuNzR8NTQ1LjEx'>
+    <rect x='5.48' y='481.74' width='73.35' height='63.37' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNS40OHwxNTIuMTh8NDgxLjc0fDU0NS4xMQ==)'>
+<g clip-path='url(#cpNS40OHw3OC44M3w0ODEuNzR8NTQ1LjEx)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzguODN8MTUyLjE4fDQ4MS43NHw1NDUuMTE='>
+    <rect x='78.83' y='481.74' width='73.35' height='63.37' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzguODN8MTUyLjE4fDQ4MS43NHw1NDUuMTE=)'>
 <text x='147.80' y='516.45' text-anchor='end' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='20.05px' lengthAdjust='spacingAndGlyphs'>Child</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>


### PR DESCRIPTION
closes #65 

# Preparing for {ggplot2} v3.5.2.9001

This PR addresses the impacts of changes to the forcoming release of {ggplot2} by making the following updates:

- Replacing the deprecated `geom_errorbarh()` with `geom_errorbar()` and updating the `height` argument to `width` to ensure compatibility,
- Addressing `tidyselect` feedback, for example by selecting variables as strings instead of using `.data$predictor`,
- Updating the snapshot plots used in the {testthat} suite to reflect changes "under the hood" that were causing test failures, despite the plots appearing identical.

Additionally, a key dependency for the `table_or` function, {gtExtras}, is also affected by changes to {ggplot2}. To resolve the resulting error, an issue and pull request have been submitted to {gtExtras}. In the meantime, a temporary measure has been implemented by copying certain functions from {gtExtras} to {plotor} and modifying them to work with the latest version of {ggplot2}. Once {gtExtras} is updated, this temporary file will be removed, as it will no longer be needed.