### PR TITLE
Adds a parameter to control whether assumption tests are run

### DIFF
--- a/R/plot_or.R
+++ b/R/plot_or.R
@@ -8,6 +8,7 @@
 #' @param glm_model_results Results from a binomial Generalised Linear Model (GLM), as produced by [stats::glm()].
 #' @param conf_level Numeric value between 0.001 and 0.999 (default = 0.95) specifying the confidence level for the confidence interval.
 #' @param confint_fast_estimate Boolean (default = `FALSE`) indicating whether to use a faster estimate of the confidence interval. Note: this assumes normally distributed data, which may not be suitable for your data.
+#' @param assumption_checks Boolean (default = `TRUE`) indicating whether to conduct checks to ensure that the assumptions of logistic regression are met.
 #'
 #' @return
 #' The function returns an object of class `gg` and `ggplot`, which can be
@@ -49,18 +50,21 @@
 plot_or <- function(
   glm_model_results,
   conf_level = 0.95,
-  confint_fast_estimate = FALSE
+  confint_fast_estimate = FALSE,
+  assumption_checks = TRUE
 ) {
   # data and input checks ----
   # check the model is logistic regression
   valid_glm_model <- validate_glm_model(glm_model_results)
 
-  # check logistic regression assumptions
-  valid_assumptions <- check_assumptions(
-    glm = glm_model_results,
-    details = FALSE,
-    confint_fast_estimate = confint_fast_estimate
-  )
+  # check logistic regression assumptions if the user requested it
+  if (assumption_checks) {
+    valid_assumptions <- check_assumptions(
+      glm = glm_model_results,
+      details = FALSE,
+      confint_fast_estimate = confint_fast_estimate
+    )
+  }
 
   # limit conf_level to between 0.001 and 0.999
   conf_level <- validate_conf_level_input(conf_level)
@@ -119,6 +123,7 @@ plot_or <- function(
 #' @param conf_level Numeric value between 0.001 and 0.999 (default = 0.95) specifying the confidence level for the confidence interval.
 #' @param output String describing of the output type (default = 'tibble'). Options include 'tibble' and 'gt'.
 #' @param confint_fast_estimate Boolean (default = `FALSE`) indicating whether to use a faster estimate of the confidence interval. Note: this assumes normally distributed data, which may not be suitable for your data.
+#' @param assumption_checks Boolean (default = `TRUE`) indicating whether to conduct checks to ensure that the assumptions of logistic regression are met.
 #'
 #' @returns
 #' The returned object depends on the `output` parameter:
@@ -152,18 +157,21 @@ table_or <- function(
   glm_model_results,
   conf_level = 0.95,
   output = 'tibble',
-  confint_fast_estimate = FALSE
+  confint_fast_estimate = FALSE,
+  assumption_checks = TRUE
 ) {
   # data and input checks ----
   # check the model is logistic regression
   valid_glm_model <- validate_glm_model(glm_model_results)
 
-  # check logistic regression assumptions
-  valid_assumptions <- check_assumptions(
-    glm = glm_model_results,
-    details = FALSE,
-    confint_fast_estimate = confint_fast_estimate
-  )
+  # check logistic regression assumptions if the user requested it
+  if (assumption_checks) {
+    valid_assumptions <- check_assumptions(
+      glm = glm_model_results,
+      details = FALSE,
+      confint_fast_estimate = confint_fast_estimate
+    )
+  }
 
   # limit conf_level to between 0.001 and 0.999
   conf_level <- validate_conf_level_input(conf_level)

--- a/tests/testthat/test-plot_or.R
+++ b/tests/testthat/test-plot_or.R
@@ -89,7 +89,7 @@ testthat::test_that("`table_or()` and `plot_or()` handle issues gracefully", {
 })
 
 ## test `assumption_checks` parameter works
-# setting to `TRUE` with models with known issues should result in a warning and should be silent if setting to `FALSE`
+# setting to `FALSE` with models with known issues should not result in warnings
 testthat::test_that("`assumption_checks` parameter works as expected", {
 
   # 1. list some models that result in at least one warning for assumptions

--- a/tests/testthat/test-plot_or.R
+++ b/tests/testthat/test-plot_or.R
@@ -88,6 +88,34 @@ testthat::test_that("`table_or()` and `plot_or()` handle issues gracefully", {
   })
 })
 
+## test `assumption_checks` parameter works
+# setting to `TRUE` with models with known issues should result in a warning and should be silent if setting to `FALSE`
+testthat::test_that("`assumption_checks` parameter works as expected", {
+
+  # 1. list some models that result in at least one warning for assumptions
+  list_models <- c(
+    'lr_diabetes.Rds',
+    'lr_infert.Rds'
+  )
+
+  # 2. iterate over these models and test
+  purrr::walk(
+    .x = list_models,
+    .f = \(.x) {
+      # load the model
+      lr <- readRDS(file = testthat::test_path('test_data', .x))
+
+      # test that warnings are not raised if `assumption_checks` is FALSE
+      testthat::expect_silent({
+        plotor::plot_or(lr, assumption_checks = FALSE)
+      })
+      testthat::expect_silent({
+        plotor::table_or(lr, assumption_checks = FALSE)
+      })
+    }
+  )
+})
+
 # validation functions ---------------------------------------------------------
 ## conf_level_input() ----
 testthat::test_that("`validate_conf_level_input()` works as expected", {


### PR DESCRIPTION
closes #75 

This pull request (PR) introduces a new parameter, `assumption_checks`, to both `plot_or()` and `table_or()`. This parameter controls whether tests for the assumptions of logistic regression are conducted, with the default setting set to `TRUE`.

By adding this parameter, analysts can choose whether the enable or disable automated tests for their supplied {glm} logistic regression model.