### PR TITLE
:bug: Ensure function `anonymise_count_values()` is not exported

### DIFF
--- a/R/plot_or.R
+++ b/R/plot_or.R
@@ -859,6 +859,7 @@ suggest_check_or <- function(
 #' @param var A numeric vector containing count data.
 #'
 #' @return A character vector of anonymised counts.
+#' @noRd
 anonymise_count_values <- function(var) {
   # Ensure `var` is a numeric vector
   var <- as.numeric(var)


### PR DESCRIPTION
Adds `@noRd` to the documentation for `anonymise_count_values()` to ensure it is not exported. 